### PR TITLE
Upgrade the unicode properties package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "deep-equal": "^1.0.0",
         "dfa": "^1.2.0",
         "tiny-inflate": "^1.0.2",
-        "unicode-properties": "^1.2.2",
+        "unicode-properties": "^1.4.0",
         "unicode-trie": "^2.0.0"
       },
       "devDependencies": {
@@ -8916,21 +8916,12 @@
       }
     },
     "node_modules/unicode-properties": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.3.1.tgz",
-      "integrity": "sha512-nIV3Tf3LcUEZttY/2g4ZJtGXhWwSkuLL+rCu0DIAMbjyVPj+8j5gNVz4T/sVbnQybIsd5SFGkPKg/756OY6jlA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "unicode-trie": "^2.0.0"
-      }
-    },
-    "node_modules/unicode-properties/node_modules/unicode-trie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
-      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-      "dependencies": {
-        "pako": "^0.2.5",
-        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/unicode-property-aliases-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dfa": "^1.2.0",
     "@foliojs-fork/restructure": "^2.0.2",
     "tiny-inflate": "^1.0.2",
-    "unicode-properties": "^1.2.2",
+    "unicode-properties": "^1.4.0",
     "unicode-trie": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This version of the unicode-properties package includes a fix that allows it to be used in the browser. https://github.com/foliojs/unicode-properties/pull/2

It follows that packages that consume this one, such as libraries for building PDFs, should also become more compatible.
See a related issue in pdfmake [here](https://github.com/bpampuch/pdfmake/issues/2429#issuecomment-2467638803).